### PR TITLE
Fix new features starting with 50%

### DIFF
--- a/app/controllers/feature_controller.rb
+++ b/app/controllers/feature_controller.rb
@@ -34,7 +34,7 @@ class FeatureController < ApplicationController
       flash[:error] = "Features names cannot contains \":\""
       redirect_to controller: :feature, action: :new
     else
-      redis_connection.set("feature:#{params[:feature]}:percentage", 50)
+      redis_connection.set("feature:#{params[:feature]}:percentage", 0)
       redirect_to controller: :dashboard, action: :index
     end
   end


### PR DESCRIPTION
This aims to solve the problem that we had when creating a new feature: It is set to 50% automatically.
This sets the percentage to 0%, since we should be able to control it before it goes live, not having the risk to have it open for 50% of the base accidentally.
This closes #17.